### PR TITLE
add custom logic to handle array/struct/float column

### DIFF
--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -71,8 +71,8 @@
 
     {%- set tables_compared -%}
     {{ audit_helper.compare_queries(
-        a_relation = model_query,
-        b_relation = compare_model_query,
+        a_query = model_query,
+        b_query = compare_model_query,
         summarize = False
     ) }}
     {%- endset -%}

--- a/macros/dmt_unit_test.sql
+++ b/macros/dmt_unit_test.sql
@@ -60,13 +60,13 @@
     {% set model_query %}
       SELECT 
         {{ cols|join(", ") }}
-      FROM model
+      FROM {{ model }}
     {% endset %}
 
     {% set compare_model_query %}
       SELECT 
         {{ cols|join(", ") }}
-      FROM compare_model
+      FROM {{ compare_model }}
     {% endset %}
 
     {%- set tables_compared -%}


### PR DESCRIPTION
float column round to 3 digits after decimal point and compare
array/struct column cast to json string and compare


This is a:
- [ ] bug fix PR with no breaking changes
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my macros (and models if applicable)
